### PR TITLE
Update for 2017 lodging

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -17,4 +17,5 @@ Sponsorship: [sponsorship@cppnow.org](sponsorship@cppnow.org)
 
 ----------------
 Hotel:	Aspen Meadows Resort Phone: +1.800.452.4240
-Reservations: Please reserve your room for 2013 using the Aspen Meadows online reservation system
+
+Reservations: Please [reserve your room using the Aspen Meadows online reservation system]({{site.baseurl}}/lodging/)

--- a/lodging.md
+++ b/lodging.md
@@ -29,7 +29,7 @@ Although we have a large block of rooms at the Aspen Meadows for C++Now, we expe
 
 <br />
 
-Please reserve your room for 2016 using <a href="https://aws.passkey.com/g/54941837">the Aspen Meadows online reservation system</a> or by calling (800) 452-4240 (remember that the reception will be Monday evening and sessions will start Tuesday morning)
+Please reserve your room for 2017 using <a href="https://aws.passkey.com/go/softwarefreedomconservancy2017">the Aspen Meadows online reservation system</a> or by calling (800) 452-4240 (remember that the reception will be Monday evening and sessions will start Tuesday morning)
 
 <br />
 


### PR DESCRIPTION
Change the date and URL on the lodging page.
Remove the reference to 2013 on the contact page and add a link to the
lodging page so we don’t need update the contact page every year.